### PR TITLE
Fix spelling of Schaeffer and building for a path with spaces

### DIFF
--- a/BuildHelper/BuildHelper.csproj
+++ b/BuildHelper/BuildHelper.csproj
@@ -90,8 +90,8 @@
 			  dotnet build -f $(TargetFramework) -c $(Configuration)
 			  
 			  ECHO [#4] Copying $(Configuration) TheArchive.Core.dll to out directory.
-			  if exist $(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.dll copy /y $(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.dll $(MSBuildProjectDirectory)\..\out\TheArchive.Core.dll
-			  if exist $(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.pdb copy /y $(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.pdb $(MSBuildProjectDirectory)\..\out\TheArchive.Core.pdb" />
+			  if exist &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.dll&quot; copy /y &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.dll&quot; &quot;$(SolutionDir)out\&quot;
+			  if exist &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.pdb&quot; copy /y &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.pdb&quot; &quot;$(SolutionDir)out\&quot;" />
 		
 	</Target>
 	

--- a/TheArchive.IL2CPP/Features/QoL/NoStoryDialog.cs
+++ b/TheArchive.IL2CPP/Features/QoL/NoStoryDialog.cs
@@ -19,7 +19,7 @@ namespace TheArchive.Features.QoL
 
         public override string Group => FeatureGroups.QualityOfLife;
 
-        public override string Description => "Removes all level-based voice events that come with subtitles.\naka Schaefer-be-gone";
+        public override string Description => "Removes all level-based voice events that come with subtitles.\naka Schaeffer-be-gone";
 
 #if IL2CPP
         public static new IArchiveLogger FeatureLogger { get; set; }


### PR DESCRIPTION
Currently, if the $(MSBuildProjectDirectory) macro expands into a path with a space, like `C:\Users\John Lastname\[other_directories]\GTFO_TheArchive`, the command will fail to copy due to space between the first name and last name. I've added quotes around the paths so this doesn't happen, and also changed to a different macro for the output directory to make it a bit shorter.