### PR TITLE
Allow for Building on Linux with Dark Haxx™

### DIFF
--- a/BuildHelper/BuildHelper.csproj
+++ b/BuildHelper/BuildHelper.csproj
@@ -12,6 +12,8 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'R_ML|AnyCPU'">
 		<TargetFramework>net472</TargetFramework>
+		<TargetFrameworkIdentifier>.NETCOREAPP</TargetFrameworkIdentifier>
+		<TargetFrameworkVersion>4.7.2</TargetFrameworkVersion>
 		<DefineConstants>TRACE</DefineConstants>
 		<Optimize>true</Optimize>
 		<DebugType>pdbonly</DebugType>
@@ -20,6 +22,8 @@
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'R_BIE|AnyCPU'">
 		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworkIdentifier>.NETCOREAPP</TargetFrameworkIdentifier>
+		<TargetFrameworkVersion>6.0</TargetFrameworkVersion>
 		<DefineConstants>TRACE</DefineConstants>
 		<Optimize>true</Optimize>
 		<PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,7 +35,22 @@
 
 	<Target Name="Buildthing" AfterTargets="Build">
 		<Message Importance="High" Text="[#0] Cleaning out directory" />
-		<Exec Command="REM&#xD;&#xA;		  if exist $(MSBuildProjectDirectory)\..\out\TheArchive.Core.dll del $(MSBuildProjectDirectory)\..\out\TheArchive.Core.dll&#xD;&#xA;		  if exist $(MSBuildProjectDirectory)\..\out\TheArchive.Core.pdb del $(MSBuildProjectDirectory)\..\out\TheArchive.Core.pdb" />
+		<Exec Condition="!$([MSBuild]::IsOSUnixLike())"
+			  Command="
+			  	REM&#xD;&#xA;
+				if exist $(MSBuildProjectDirectory)\..\out\TheArchive.Core.dll del $(MSBuildProjectDirectory)\..\out\TheArchive.Core.dll&#xD;&#xA;
+				if exist $(MSBuildProjectDirectory)\..\out\TheArchive.Core.pdb del $(MSBuildProjectDirectory)\..\out\TheArchive.Core.pdb"
+		/>
+		<Exec Condition="$([MSBuild]::IsOSUnixLike())"
+			  Command="
+				if [ -e '$(MSBuildProjectDirectory)/../out/TheArchive.Core.dll' ]; then
+					rm '$(MSBuildProjectDirectory)/../out/TheArchive.Core.dll'
+				fi
+
+				if [ -e '$(MSBuildProjectDirectory)/../out/TheArchive.Core.pdb' ]; then
+					rm '$(MSBuildProjectDirectory)/../out/TheArchive.Core.pdb'
+				fi
+		"/>
 
 		<Message Importance="High" Text="[#0.1] Building Core Mod" />
 		<MSBuild Projects="$(MSBuildProjectDirectory)\..\TheArchive.Core\TheArchive.Core.csproj" ContinueOnError="false" BuildInParallel="false" />
@@ -70,29 +89,68 @@
 
 	<!-- Frankenstein build smh -->
 	<Target Name="BuildLastSteps" AfterTargets="Buildthing" >
-		<Exec Command="ECHO [#2] Building IL2CPP/MONO Support-Modules ...
-			  cd $(MSBuildProjectDirectory)\..\TheArchive.IL2CPP\
-			  ECHO [#2.1] Building IL2CPP Support-Module ...
-			  dotnet clean -f $(TargetFramework) -c $(Configuration)
-			  dotnet build -f $(TargetFramework) -c $(Configuration)
-			  
-			  cd $(MSBuildProjectDirectory)\..\TheArchive.MONO\
-			  if '$(Configuration)' == 'R_ML' (
-			  ECHO [#2.2] Building MONO Support-Module ...
-			  dotnet build -f $(TargetFramework) -c $(Configuration)
-			  ) ELSE (
-			  if exist $(MSBuildProjectDirectory)\..\TheArchive.Core\Resources\TheArchive.MONO.dll del /F $(MSBuildProjectDirectory)\..\TheArchive.Core\Resources\TheArchive.MONO.dll
-			  ECHO DUMMY >  $(MSBuildProjectDirectory)\..\TheArchive.Core\Resources\TheArchive.MONO.dll
-			  )
-			  ECHO [#3] Building Core Mod
-			  cd $(MSBuildProjectDirectory)\..\TheArchive.Core\
-			  dotnet clean -f $(TargetFramework) -c $(Configuration)
-			  dotnet build -f $(TargetFramework) -c $(Configuration)
-			  
-			  ECHO [#4] Copying $(Configuration) TheArchive.Core.dll to out directory.
-			  if exist &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.dll&quot; copy /y &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.dll&quot; &quot;$(SolutionDir)out\&quot;
-			  if exist &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.pdb&quot; copy /y &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.pdb&quot; &quot;$(SolutionDir)out\&quot;" />
-		
+		<Exec Condition="!$([MSBuild]::IsOSUnixLike())"
+			  Command="
+				ECHO [#2] Building IL2CPP/MONO Support-Modules ...
+			  	cd $(MSBuildProjectDirectory)\..\TheArchive.IL2CPP\
+			  	ECHO [#2.1] Building IL2CPP Support-Module ...
+			  	dotnet clean -f $(TargetFramework) -c $(Configuration)
+			  	dotnet build -f $(TargetFramework) -c $(Configuration)
+
+			  	cd $(MSBuildProjectDirectory)\..\TheArchive.MONO\
+			  	if '$(Configuration)' == 'R_ML' (
+			  	ECHO [#2.2] Building MONO Support-Module ...
+			  	dotnet build -f $(TargetFramework) -c $(Configuration)
+			  	) ELSE (
+			  	if exist $(MSBuildProjectDirectory)\..\TheArchive.Core\Resources\TheArchive.MONO.dll del /F $(MSBuildProjectDirectory)\..\TheArchive.Core\Resources\TheArchive.MONO.dll
+			  	ECHO DUMMY >  $(MSBuildProjectDirectory)\..\TheArchive.Core\Resources\TheArchive.MONO.dll
+			  	)
+			  	ECHO [#3] Building Core Mod
+			  	cd $(MSBuildProjectDirectory)\..\TheArchive.Core\
+			  	dotnet clean -f $(TargetFramework) -c $(Configuration)
+			  	dotnet build -f $(TargetFramework) -c $(Configuration)
+
+			  	ECHO [#4] Copying $(Configuration) TheArchive.Core.dll to out directory.
+			  	if exist &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.dll&quot; copy /y &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.dll&quot; &quot;$(SolutionDir)out\&quot;
+			  	if exist &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.pdb&quot; copy /y &quot;$(MSBuildProjectDirectory)\..\TheArchive.Core\bin\$(Configuration)\TheArchive.Core.pdb&quot; &quot;$(SolutionDir)out\&quot;"
+		/>
+		<Exec Condition="$([MSBuild]::IsOSUnixLike())"
+			  Command="
+				echo '[#2] Building IL2CPP/MONO Support-Modules ...'
+					cd '$(MSBuildProjectDirectory)/../TheArchive.IL2CPP/'
+
+				echo '[#2.1] Building IL2CPP Support-Module ...'
+					dotnet clean -f $(TargetFramework) -c $(Configuration)
+					dotnet build -f $(TargetFramework) -c $(Configuration)
+					cd '$(MSBuildProjectDirectory)/../TheArchive.MONO/'
+						if [ '$(Configuration)' == 'R_ML' ]; then
+							echo '[#2.2] Building MONO Support-Module ...'
+							dotnet build -f $(TargetFramework) -c $(Configuration)
+						else
+						if [ -e '$(MSBuildProjectDirectory)/../TheArchive.Core/Resources/TheArchive.MONO.dll' ]; then
+							rm -f '$(MSBuildProjectDirectory)/../TheArchive.Core/Resources/TheArchive.MONO.dll'
+						fi
+						echo 'DUMMY' > '$(MSBuildProjectDirectory)/../TheArchive.Core/Resources/TheArchive.MONO.dll'
+						fi
+
+				echo '[#3] Building Core Mod'
+					cd '$(MSBuildProjectDirectory)/../TheArchive.Core/'
+						dotnet clean -f $(TargetFramework) -c $(Configuration)
+						dotnet build -f $(TargetFramework) -c $(Configuration)
+
+				echo '[#4] Copying $(Configuration) TheArchive.Core.dll to out/Localization directory.'
+					if [ -e '$(MSBuildProjectDirectory)/../TheArchive.Core/bin/$(Configuration)/TheArchive.Core.dll' ]; then
+						cp '$(MSBuildProjectDirectory)/../TheArchive.Core/bin/$(Configuration)/TheArchive.Core.dll' '$(SolutionDir)out/'
+					fi
+					if [ -e '$(MSBuildProjectDirectory)/../TheArchive.Core/bin/$(Configuration)/TheArchive.Core.pdb' ]; then
+						cp '$(MSBuildProjectDirectory)/../TheArchive.Core/bin/$(Configuration)/TheArchive.Core.pdb' '$(SolutionDir)out/'
+					fi
+
+				echo '[#5] Copying Localizations to out directory.'
+					if [ -d '$(MSBuildProjectDirectory)/../TheArchive.Core/Localization' ]; then
+						cp -r '$(MSBuildProjectDirectory)/../TheArchive.Core/Localization/' '$(SolutionDir)out/Localization/'
+				fi
+		"/>
 	</Target>
 	
 	<PropertyGroup>

--- a/TheArchive.Core/TheArchive.Core.csproj
+++ b/TheArchive.Core/TheArchive.Core.csproj
@@ -14,7 +14,7 @@
 		</NuGetPackageImportStamp>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'R_ML|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)' == 'R_ML'">
 		<TargetFramework>net472</TargetFramework>
 		<DefineConstants>TRACE</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -23,7 +23,7 @@
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<ErrorReport>prompt</ErrorReport>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'R_BIE|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)' == 'R_BIE'">
 		<TargetFramework>net6.0</TargetFramework>
 		<DefineConstants>TRACE</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -63,7 +63,7 @@
 		<None Include="packages.config" />
 	</ItemGroup>
 
-	<PropertyGroup>
+	<PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
 		<PreBuildEvent>
 			cd $(MSBuildProjectDirectory)\Resources\
 			if exist TheArchive.IL2CPP.dll (
@@ -78,6 +78,23 @@
 				ECHO Generating MONO dummy dll ...
 				ECHO DUMMY &gt; TheArchive.MONO.dll
 			)
+		</PreBuildEvent>
+	</PropertyGroup>
+	<PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+		<PreBuildEvent>
+			cd "$(MSBuildProjectDirectory)/Resources"
+			if [ -f "TheArchive.IL2CPP.dll" ]; then
+			    echo "Not generating IL2CPP dummy dll"
+			else
+			    echo "Generating IL2CPP dummy dll ..."
+			    echo "DUMMY" > TheArchive.IL2CPP.dll
+			fi
+			if [ -f "TheArchive.MONO.dll" ]; then
+			    echo "Not generating MONO dummy dll"
+			else
+			    echo "Generating MONO dummy dll ..."
+			    echo "DUMMY" > TheArchive.MONO.dll
+			fi
 		</PreBuildEvent>
 	</PropertyGroup>
 	<ItemGroup>

--- a/TheArchive.IL2CPP/TheArchive.IL2CPP.csproj
+++ b/TheArchive.IL2CPP/TheArchive.IL2CPP.csproj
@@ -14,7 +14,7 @@
 		<NuGetPackageImportStamp>
 		</NuGetPackageImportStamp>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'R_ML|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)' == 'R_ML'">
 		<TargetFramework>net472</TargetFramework>
 		<DefineConstants>TRACE;IL2CPP</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -23,7 +23,7 @@
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<ErrorReport>prompt</ErrorReport>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'R_BIE|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)' == 'R_BIE'">
 		<TargetFramework>net6.0</TargetFramework>
 		<DefineConstants>TRACE;IL2CPP</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -171,10 +171,16 @@
 		<Folder Include="Properties\" />
 	</ItemGroup>
 
-	<PropertyGroup>
+	<PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
 		<PostBuildEvent>
 			cd $(MSBuildProjectDirectory)
 			copy /y bin\$(Configuration)\TheArchive.IL2CPP.dll ..\TheArchive.Core\Resources\TheArchive.IL2CPP.dll
+		</PostBuildEvent>
+	</PropertyGroup>
+	<PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+		<PostBuildEvent>
+			cd $(MSBuildProjectDirectory)
+			cp bin/$(Configuration)/TheArchive.IL2CPP.dll ../TheArchive.Core/Resources/TheArchive.IL2CPP.dll
 		</PostBuildEvent>
 	</PropertyGroup>
 </Project>

--- a/TheArchive.MONO/TheArchive.MONO.csproj
+++ b/TheArchive.MONO/TheArchive.MONO.csproj
@@ -13,7 +13,7 @@
 		<Deterministic>true</Deterministic> 
 		<Configurations>R_ML;R_BIE</Configurations>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'R_ML|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)' == 'R_ML'">
 		<TargetFramework>net472</TargetFramework>
 		<OutputPath>bin\R_ML\</OutputPath>
 		<DefineConstants>TRACE;MONO</DefineConstants>
@@ -22,7 +22,7 @@
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<ErrorReport>prompt</ErrorReport>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='R_BIE|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)'=='R_BIE'">
 		<TargetFramework>net6.0</TargetFramework>
 		<OutputPath>bin\R_BIE\</OutputPath>
 		<DefineConstants>TRACE;MONO</DefineConstants>
@@ -311,10 +311,16 @@
 	  <Reference Include="System.Net.Http" />
 	</ItemGroup>
 	
-	<PropertyGroup>
+	<PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
 		<PostBuildEvent>
 			cd $(MSBuildProjectDirectory)
 			copy /y bin\$(Configuration)\TheArchive.MONO.dll ..\TheArchive.Core\Resources\TheArchive.MONO.dll
+		</PostBuildEvent>
+	</PropertyGroup>
+	<PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+		<PostBuildEvent>
+			cd $(MSBuildProjectDirectory)
+			cp bin/$(Configuration)/TheArchive.MONO.dll ../TheArchive.Core/Resources/TheArchive.MONO.dll
 		</PostBuildEvent>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
What I've done is simply translating the batch commands to their `sh` equivalents, ~~a tedious task that I'd never get my hands on manually, thx Copilot!~~
This is a very primitive attempt of building The Archive on Linux(and possibly other Unix-like OSes, provided .NET SDK, and `coreutils`-or-equivalent are installed). As changes to Windows batchfiles are included, this "patch" needs to be tested on Windows to see whether the formatting messes with VS.
As the process is not automated, dependency resolution(a la `dotnet restore`) has to be done manually with each submodule before building, the following procedure is concluded:
1. run `dotnet restore --force /property:Configuration=R_xx`(with `R_xx` your desired modloader) for `TheArchive_Core`, `TheArchive_IL2CPP`, and `TheArchive_MONO`. No need for `BuildHelper` it seems, as it helps itself out. ~~Pretty helpful BuildHelper!~~
2. then run `dotnet build --configuration R_xx` under the root. Again with `R_xx` your desired modloader.
3. Profit??
I have tested the produced binary and it seems to be running well on my machine, I hope anybody out there could help with this PR, XOXO <3