### PR TITLE
Kill indicator fix update

### DIFF
--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -75,6 +75,7 @@ internal class KillIndicatorFix : Feature
     public override void Init()
     {
         hasDamageSync = LoaderWrapper.IsModInstalled(DAMAGE_SYNC_GUID);
+        if (!hasDamageSync) FeatureLogger.Notice("Damage Sync is installed, disabling damage sync component.");
 
         RundownManager.add_OnExpeditionGameplayStarted((Action)OnRundownStart);
     }
@@ -164,10 +165,10 @@ internal class KillIndicatorFix : Feature
         public static void Prefix(Dam_EnemyDamageBase __instance, float dam, Agent sourceAgent, Vector3 position)
         {
             if (SNet.IsMaster) return;
-            PlayerAgent p = sourceAgent.TryCast<PlayerAgent>();
+            PlayerAgent p = sourceAgent?.TryCast<PlayerAgent>();
             if (p == null) // Check damage was done by a player
             {
-                if (Settings.DebugLog) FeatureLogger.Notice($"Could not find PlayerAgent, damage was done by agent of type: {sourceAgent.m_type}.");
+                if (Settings.DebugLog) FeatureLogger.Notice($"Could not find PlayerAgent.");
                 return;
             }
             if (p.Owner.IsBot) return; // Check player isnt a bot
@@ -212,10 +213,10 @@ internal class KillIndicatorFix : Feature
         public static void Prefix(Dam_EnemyDamageBase __instance, float dam, Agent sourceAgent, Vector3 position)
         {
             if (SNet.IsMaster) return;
-            PlayerAgent p = sourceAgent.TryCast<PlayerAgent>();
+            PlayerAgent p = sourceAgent?.TryCast<PlayerAgent>();
             if (p == null) // Check damage was done by a player
             {
-                if (Settings.DebugLog) FeatureLogger.Notice($"Could not find PlayerAgent, damage was done by agent of type: {sourceAgent.m_type}.");
+                if (Settings.DebugLog) FeatureLogger.Notice($"Could not find PlayerAgent.");
                 return;
             }
             if (p.Owner.IsBot) return; // Check player isnt a bot

--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -75,7 +75,7 @@ internal class KillIndicatorFix : Feature
     public override void Init()
     {
         hasDamageSync = LoaderWrapper.IsModInstalled(DAMAGE_SYNC_GUID);
-        if (!hasDamageSync) FeatureLogger.Notice("Damage Sync is installed, disabling damage sync component.");
+        if (hasDamageSync) FeatureLogger.Notice("Damage Sync is installed, disabling damage sync component.");
 
         RundownManager.add_OnExpeditionGameplayStarted((Action)OnRundownStart);
     }

--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -52,10 +52,6 @@ internal class KillIndicatorFix : Feature
         [FSDescription("Determines how long (in ms) an enemy is tracked for after getting shot at.")]
         public int TagBufferPeriod { get; set; } = 1000;
 
-        [FSDisplayName("Marker Life Time")]
-        [FSDescription("Determines how long (in ms) a shown kill marker is tracked for to prevent duplicates.")]
-        public int MarkerLifeTime { get; set; } = 3000;
-
         [FSHide]
         [FSDescription("Prints debug info to console.")]
         public bool DebugLog { get; set; } = false;


### PR DESCRIPTION
- Updated the logic to match the [Thunderstore version](https://thunderstore.io/c/gtfo/p/randomuserhi/KillIndicatorFix/).
- Disables `DamageSync` part of the feature when the [Thunderstore version](https://thunderstore.io/c/gtfo/p/randomuserhi/DamageSync/) is installed.

Feel free to not include the [extra code for sentry support](https://github.com/AuriRex/GTFO_TheArchive/pull/78/commits/a640f2488955f241b6daf2f305f3cfca13e09e4a) as that is waiting for a network layer to be added.