### PR TITLE
Bio Scanner Red Dot Fix

### DIFF
--- a/TheArchive.Essentials/Features/Fixes/BioTrackerSmallRedDotFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/BioTrackerSmallRedDotFix.cs
@@ -1,0 +1,34 @@
+﻿using Enemies;
+using TheArchive.Core.Attributes;
+using TheArchive.Core.FeaturesAPI;
+using static TheArchive.Utilities.Utils;
+
+namespace TheArchive.Features.Fixes;
+
+[EnableFeatureByDefault]
+[RundownConstraint(RundownFlags.RundownSix, RundownFlags.Latest)]
+internal class BioTrackerSmallRedDotFix : Feature
+{
+    public override string Name => "Bio Tracker Small Red Dots";
+
+    public override FeatureGroup Group => FeatureGroups.Fixes;
+
+    public override string Description => "Fixes tiny red dots on the bio tracker.";
+
+#if IL2CPP
+
+    [ArchivePatch(typeof(EnemyAgent), nameof(EnemyAgent.ScannerData), patchMethodType: ArchivePatch.PatchMethodType.Setter)]
+    internal static class EnemyAgent_ScannerData_Patch
+    {
+        public static void Postfix(EnemyAgent __instance)
+        {
+            __instance.m_hasDirtyScannerColor = true;
+        }
+    }
+
+#endif
+
+#if MONO
+        // TODO
+#endif
+}


### PR DESCRIPTION
Fixes small bio scanner red dot bug that occurs when looking at enemies as they move more than 3 nodes away with the tracker out.

Refer to the [GTFO Server Post](https://discord.com/channels/408196129470152705/1255623780706029588)