### PR TITLE
Refactor KillIndicatorFix feature to not use vanilla health values 

### DIFF
--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -237,8 +237,8 @@ internal class KillIndicatorFix : Feature
             t.localHitPosition = position - owner.transform.position;
             t.timestamp = now;
 
-            fullDamageData.damage.Set(dam, __instance.HealthMax);
-            float num = AgentModifierManager.ApplyModifier(owner, AgentModifier.MeleeResistance, fullDamageData.damage.Get(__instance.HealthMax));
+            fullDamageData.damage.Set(dam, __instance.DamageMax);
+            float num = AgentModifierManager.ApplyModifier(owner, AgentModifier.MeleeResistance, fullDamageData.damage.Get(__instance.DamageMax));
             if (__instance.Owner.Locomotion.CurrentStateEnum == ES_StateEnum.Hibernate)
             {
                 fullDamageData.sleeperMulti.Set(sleeperMulti, 10);

--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -173,7 +173,8 @@ internal class KillIndicatorFix : Feature
             t.health -= num;
 
             // Show indicator when tracked health assumes enemy is dead
-            if (t.health <= 0 && !__instance.DeathIndicatorShown) {
+            if (t.health <= 0 && !__instance.DeathIndicatorShown) 
+            {
                 GuiManager.CrosshairLayer?.ShowDeathIndicator(position);
                 __instance.DeathIndicatorShown = true;
                 disableHitIndicator = true;
@@ -234,7 +235,8 @@ internal class KillIndicatorFix : Feature
             t.health -= num;
 
             // Show indicator when tracked health assumes enemy is dead
-            if (t.health <= 0 && !__instance.DeathIndicatorShown) {
+            if (t.health <= 0 && !__instance.DeathIndicatorShown) 
+            {
                 GuiManager.CrosshairLayer?.ShowDeathIndicator(position);
                 __instance.DeathIndicatorShown = true;
                 disableHitIndicator = true;

--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -51,10 +51,9 @@ internal class KillIndicatorFix : Feature
         [FSDescription("Determines how long (in ms) an enemy is tracked for after getting shot at.")]
         public int TagBufferPeriod { get; set; } = 1000;
 
-        //[FSHide]
-        [FSDisplayName("Debug")]
+        [FSHide]
         [FSDescription("Prints debug info to console.")]
-        public bool DebugLog { get; set; } = true;
+        public bool DebugLog { get; set; } = false;
     }
 
     private class Tag
@@ -267,7 +266,7 @@ internal class KillIndicatorFix : Feature
 
 #endregion
 
-#region Fix for sentries (Unfinnished)
+#region Fix for sentries (WIP)
 #if false
 
     // Determine if the shot was performed by a sentry or player

--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -283,6 +283,24 @@ internal class KillIndicatorFix : Feature
         }
     }
 
+    [ArchivePatch(typeof(Dam_EnemyDamageBase), nameof(Dam_EnemyDamageBase.ReceiveSetHealth), new Type[]
+    {
+        typeof(pSetHealthData)
+    })]
+    private class Dam_EnemyDamageBase_ReceiveSetHealth_Patch
+    {
+        private static void Postfix(Dam_EnemyDamageBase __instance, pSetHealthData data)
+        {
+            if (SNet.IsMaster) return;
+
+            ushort id = __instance.Owner.GlobalID;
+            if (!taggedEnemies.ContainsKey(id)) return;
+
+            Tag t = taggedEnemies[id];
+            t.health = data.health.Get(__instance.HealthMax);
+        }
+    }
+
 #endregion
 
 #region Fix for sentries (WIP)

--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -93,12 +93,14 @@ internal class KillIndicatorFix : Feature
             if (SNet.IsMaster) return;
             if (__instance.m_currentStateName == state || state != EB_States.Dead) return;
 
-            try {
+            try
+            {
                 EnemyAgent owner = __instance.m_ai.m_enemyAgent;
                 ushort id = owner.GlobalID;
                 long now = ((DateTimeOffset)DateTime.Now).ToUnixTimeMilliseconds();
 
-                if (taggedEnemies.ContainsKey(id)) {
+                if (taggedEnemies.ContainsKey(id))
+                {
                     Tag t = taggedEnemies[id];
 
                     if (Settings.DebugLog)
@@ -107,22 +109,32 @@ internal class KillIndicatorFix : Feature
                         else
                             FeatureLogger.Info($"Received kill update for enemy that was tagged in the future? Possibly long overflow...");
 
-                    if (t.timestamp <= now && now - t.timestamp < Settings.TagBufferPeriod) {
-                        if (!owner.Damage.DeathIndicatorShown) {
+                    if (t.timestamp <= now && now - t.timestamp < Settings.TagBufferPeriod)
+                    {
+                        if (!owner.Damage.DeathIndicatorShown)
+                        {
                             FeatureLogger.Info($"Client side marker was not shown, showing server side one.");
 
                             GuiManager.CrosshairLayer?.ShowDeathIndicator(owner.transform.position + t.localHitPosition);
                             owner.Damage.DeathIndicatorShown = true;
-                        } else if (Settings.DebugLog) {
+                        } 
+                        else if (Settings.DebugLog)
+                        {
                             FeatureLogger.Info($"Client side marker was shown, not showing server side one.");
                         }
-                    } else if (Settings.DebugLog) {
+                    }
+                    else if (Settings.DebugLog) 
+                    {
                         FeatureLogger.Info($"Client was no longer interested in this enemy, marker will not be shown.");
                     }
 
                     taggedEnemies.Remove(id);
                 }
-            } catch (Exception e) { FeatureLogger.Error($"Something went wrong:\n{e}"); }
+            }
+            catch (Exception e)
+            {
+                FeatureLogger.Error($"Something went wrong:\n{e}");
+            }
         }
     }
 
@@ -375,12 +387,14 @@ internal class KillIndicatorFix : Feature
             // TODO(randomuserhi): OnReceive, display corresponding hit marker
 
             EnemyAgent? targetEnemy = target.TryCast<EnemyAgent>();
-            if (targetEnemy != null) {
+            if (targetEnemy != null)
+            {
                 Dam_EnemyDamageLimb dam = targetEnemy.Damage.DamageLimbs[limbID];
                 dam.ShowHitIndicator(hitWeakspot, willDie, position, hitArmor);
             }
             PlayerAgent? targetPlayer = target.TryCast<PlayerAgent>();
-            if (targetPlayer != null) {
+            if (targetPlayer != null)
+            {
                 GuiManager.CrosshairLayer.PopFriendlyTarget();
             }
 

--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -229,6 +229,7 @@ internal class KillIndicatorFix : Feature
             // Show indicator when tracked health assumes enemy is dead
             if (t.health <= 0 && !__instance.DeathIndicatorShown) {
                 GuiManager.CrosshairLayer?.ShowDeathIndicator(position);
+                __instance.DeathIndicatorShown = true;
             }
 
             if (Settings.DebugLog)

--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -204,7 +204,7 @@ internal class KillIndicatorFix : Feature
     })]
     internal static class Dam_EnemyDamageBase_MeleeDamage_Patch
     {
-        public static void Prefix(Dam_EnemyDamageBase __instance, float dam, Agent sourceAgent, Vector3 position)
+        public static void Prefix(Dam_EnemyDamageBase __instance, float dam, Agent sourceAgent, Vector3 position, Vector3 direction, int limbID, float staggerMulti, float precisionMulti, float backstabberMulti, float sleeperMulti, bool skipLimbDestruction, DamageNoiseLevel damageNoiseLevel)
         {
             if (SNet.IsMaster) return;
             PlayerAgent p = sourceAgent?.TryCast<PlayerAgent>();
@@ -226,6 +226,11 @@ internal class KillIndicatorFix : Feature
 
             fullDamageData.damage.Set(dam, __instance.HealthMax);
             float num = AgentModifierManager.ApplyModifier(owner, AgentModifier.MeleeResistance, fullDamageData.damage.Get(__instance.HealthMax));
+            if (__instance.Owner.Locomotion.CurrentStateEnum == ES_StateEnum.Hibernate)
+            {
+                fullDamageData.sleeperMulti.Set(sleeperMulti, 10);
+                num *= fullDamageData.sleeperMulti.Get(10);
+            }
             t.health -= num;
 
             // Show indicator when tracked health assumes enemy is dead

--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -174,6 +174,7 @@ internal class KillIndicatorFix : Feature
             // Show indicator when tracked health assumes enemy is dead
             if (t.health <= 0 && !__instance.DeathIndicatorShown) {
                 GuiManager.CrosshairLayer?.ShowDeathIndicator(position);
+                __instance.DeathIndicatorShown = true;
             }
 
             if (Settings.DebugLog)


### PR DESCRIPTION
- Tracks enemy health in a separate dictionary to prevent compatibility issues
- Removed `DamageSync` component (Won't move `DamageSync` into a separate feature since its not really a fix itself)
- Fix incorrect damage calculation due to `UFloat` conversion 