### PR TITLE
Bioscanner small red dot fix unable to ping scouts

### DIFF
--- a/TheArchive.Essentials/Features/Fixes/BioTrackerSmallRedDotFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/BioTrackerSmallRedDotFix.cs
@@ -23,6 +23,10 @@ internal class BioTrackerSmallRedDotFix : Feature
         public static void Postfix(EnemyAgent __instance)
         {
             __instance.m_hasDirtyScannerColor = true;
+            EnemyScannerDataObject scannerData = __instance.ScannerData;
+            if (__instance.Locomotion.CurrentStateEnum != ES_StateEnum.Hibernate) {
+                scannerData.m_soundIndex = 0;
+            }
         }
     }
 


### PR DESCRIPTION
Scouts in other rooms are unable to be pinged after getting small-red-dot bugged due to incorrect sound index.