### PR TITLE
Kill Indicator Fix: Rounding and unnecessary sleeper multi

### DIFF
--- a/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
+++ b/TheArchive.Essentials/Features/Fixes/KillIndicatorFix.cs
@@ -241,13 +241,8 @@ internal class KillIndicatorFix : Feature
             t.timestamp = now;
 
             fullDamageData.damage.Set(dam, __instance.DamageMax);
-            float num = AgentModifierManager.ApplyModifier(owner, AgentModifier.MeleeResistance, fullDamageData.damage.Get(__instance.DamageMax));
-            if (__instance.Owner.Locomotion.CurrentStateEnum == ES_StateEnum.Hibernate)
-            {
-                fullDamageData.sleeperMulti.Set(sleeperMulti, 10);
-                num *= fullDamageData.sleeperMulti.Get(10);
-            }
-            t.health -= num;
+			float num = AgentModifierManager.ApplyModifier(owner, AgentModifier.MeleeResistance, Dam_EnemyDamageBase.RoundDamage(fullDamageData.damage.Get(__instance.DamageMax)));
+			t.health -= num;
 
             // Show indicator when tracked health assumes enemy is dead
             if (t.health <= 0 && !__instance.DeathIndicatorShown) 


### PR DESCRIPTION
The melee damage code had actually changed from the leaked R6 mono, and thus the calculation for melee damage is wrong.

After getting the decomp, it turns out sleeper multi is applied automatically so we no longer need to apply it here and they have a new rounding method.

For some reason this change wasn't reflected in guns which still do not round their damage lol.